### PR TITLE
fix: add focused index when multiple items selected

### DIFF
--- a/src/lib/Selectable.tsx
+++ b/src/lib/Selectable.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react';
-import useSelect from './useSelect';
-import { useSelectStore } from './useSelectStore';
+import { useEffect, useRef } from "react";
+import useSelect from "./useSelect";
+import { useSelectStore } from "./useSelectStore";
 
 interface SelectableProps {
   index: number;
@@ -52,6 +52,7 @@ export default function Selectable({ index, children }: SelectableProps) {
   const handleMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
     if (selectedIndexes.size > 1 && isSelected && !e.ctrlKey && !e.shiftKey) {
       selectOnlyOne(index);
+      setFocusedIndex(index);
     }
   };
 
@@ -81,11 +82,11 @@ export default function Selectable({ index, children }: SelectableProps) {
     };
 
     if (dragBoxElement) {
-      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener("mousemove", handleMouseMove);
     }
 
     return () => {
-      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener("mousemove", handleMouseMove);
     };
   }, [dragBoxElement, index, isSelected, select, unselect]);
 
@@ -94,7 +95,7 @@ export default function Selectable({ index, children }: SelectableProps) {
       ref={ref}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
-      className='temp'
+      className="temp"
     >
       {children}
     </div>

--- a/src/lib/Selectable.tsx
+++ b/src/lib/Selectable.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from "react";
-import useSelect from "./useSelect";
-import { useSelectStore } from "./useSelectStore";
+import { useEffect, useRef } from 'react';
+import useSelect from './useSelect';
+import { useSelectStore } from './useSelectStore';
 
 interface SelectableProps {
   index: number;
@@ -24,6 +24,7 @@ export default function Selectable({ index, children }: SelectableProps) {
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     setIsDragging(false);
+    setFocusedIndex(index);
 
     if (useCtrl && e.ctrlKey && !e.shiftKey) {
       if (isSelected) {
@@ -45,14 +46,11 @@ export default function Selectable({ index, children }: SelectableProps) {
       }
       selectOnlyOne(index);
     }
-
-    setFocusedIndex(index);
   };
 
   const handleMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
     if (selectedIndexes.size > 1 && isSelected && !e.ctrlKey && !e.shiftKey) {
       selectOnlyOne(index);
-      setFocusedIndex(index);
     }
   };
 
@@ -82,11 +80,11 @@ export default function Selectable({ index, children }: SelectableProps) {
     };
 
     if (dragBoxElement) {
-      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener('mousemove', handleMouseMove);
     }
 
     return () => {
-      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener('mousemove', handleMouseMove);
     };
   }, [dragBoxElement, index, isSelected, select, unselect]);
 
@@ -95,7 +93,7 @@ export default function Selectable({ index, children }: SelectableProps) {
       ref={ref}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
-      className="temp"
+      className='temp'
     >
       {children}
     </div>


### PR DESCRIPTION
### ⛑ ISSUE
- Resolve the issue where the focus is not properly set when a single selection is made on a select box without holding the `shift` key after making multiple selections.

### Before

|Multi Select|=> Click(focus idx4)|
|-|-|
|![image](https://github.com/user-attachments/assets/ca064817-49c3-4310-a153-c59c27013b4d)|![image](https://github.com/user-attachments/assets/1743e8d9-5bd6-42f1-ade7-1a425d472ab0)|

### After

|Multi Select|=> Click(focus idx2)|
|-|-|
|![image](https://github.com/user-attachments/assets/ca064817-49c3-4310-a153-c59c27013b4d)|![image](https://github.com/user-attachments/assets/dc5d462b-97f3-43a5-9520-3ff5543105a4)|

It would be an honor if you could put this PR on it. Plz 🍻